### PR TITLE
The CoinBlockerLists moved to Gitlab ! ! !

### DIFF
--- a/update-hosts
+++ b/update-hosts
@@ -1648,8 +1648,12 @@ readonly BASE_HOSTS_SOURCES="
   https://s3.amazonaws.com/lists.disconnect.me/simple_malware.txt
   https://s3.amazonaws.com/lists.disconnect.me/simple_tracking.txt
 
-  # Blocks coin miners
-  https://raw.githubusercontent.com/ZeroDot1/CoinBlockerLists/master/hosts
+  # The CoinblockerList are simple lists that can help to prevent illegal mining in the browser or other applications.
+  # CoinBlokerLists Homepage: https://zerodot1.gitlab.io/CoinBlockerListsWeb/index.html
+  https://zerodot1.gitlab.io/CoinBlockerLists/hosts 
+  # Additional lists:
+  # https://zerodot1.gitlab.io/CoinBlockerLists/hosts_browser 
+  # https://zerodot1.gitlab.io/CoinBlockerLists/hosts_optional
 "
 
 # Additional hosts file servers


### PR DESCRIPTION
The CoinBlockerLists moved to Gitlab because Microsoft acquired Github.
https://gitlab.com/ZeroDot1/CoinBlockerLists
I've made all the changes, I hope that's not a problem.

# Please make the changes available to everyone as soon as possible, the lists on Github will be deleted soon.

## https://gitlab.com/ZeroDot1/CoinBlockerLists/issues/1